### PR TITLE
Current branch can be obtained cleanly with git symbolic-ref

### DIFF
--- a/gopen
+++ b/gopen
@@ -2,7 +2,7 @@
 
 git branch >/dev/null 2>&1 || { echo "Not in a git repo"; exit 10; }
 
-branch=$( git branch 2>/dev/null | awk '/^\* / {print $2}' )
+branch=$( git symbolic-ref --short -q HEAD )
 
 remote=$(git config --get branch.${branch}.remote)
 


### PR DESCRIPTION
No need to use awk. I found the symbolic-ref usage the other day for one of my own helper scripts.
